### PR TITLE
Provide XML Schema files for portlet-model-hints.xml and custom-sql/default.xml

### DIFF
--- a/src/main/java/com/liferay/ide/idea/language/LiferayXmlSchemaProvider.java
+++ b/src/main/java/com/liferay/ide/idea/language/LiferayXmlSchemaProvider.java
@@ -1,9 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.ide.idea.language;
 
 import com.intellij.ide.highlighter.XmlFileType;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.xml.XmlFile;
@@ -32,25 +47,32 @@ public class LiferayXmlSchemaProvider extends XmlSchemaProvider {
 			psiFile = baseFile.getOriginalFile();
 		}
 
-		if (psiFile.getName().equals("portlet-model-hints.xml")) {
-			targetFileUrl = LiferayXmlSchemaProvider.class.getResource(
-			        "/xsd/liferay-portlet-model-hints_7_0_0.xsd"
-            );
-		} else if (
-				(psiFile.getName().equals("default.xml")) &&
-                (psiFile.getParent() != null) &&
-                (psiFile.getParent().getName().equals("custom-sql"))
-        ) {
-			targetFileUrl = LiferayXmlSchemaProvider.class.getResource(
-			        "/xsd/liferay-custom-sql_7_0_0.xsd"
-            );
+		String fileName = psiFile.getName();
+
+		if ("portlet-model-hints.xml".equals(fileName)) {
+			targetFileUrl = LiferayXmlSchemaProvider.class.getResource("/xsd/liferay-portlet-model-hints_7_0_0.xsd");
+		}
+		else {
+			if ("default.xml".equals(fileName)) {
+				PsiDirectory parentDirectory = psiFile.getParent();
+
+				if (parentDirectory != null) {
+					String parentDirectoryName = parentDirectory.getName();
+
+					if ("custom-sql".equals(parentDirectoryName)) {
+						targetFileUrl = LiferayXmlSchemaProvider.class.getResource("/xsd/liferay-custom-sql_7_0_0.xsd");
+					}
+				}
+			}
 		}
 
 		if (targetFileUrl != null) {
 			VirtualFile virtualFile = VfsUtil.findFileByURL(targetFileUrl);
 
 			if (virtualFile != null) {
-				PsiFile targetFile = PsiManager.getInstance(baseFile.getProject()).findFile(virtualFile);
+				PsiManager psiManager = PsiManager.getInstance(baseFile.getProject());
+
+				PsiFile targetFile = psiManager.findFile(virtualFile);
 
 				if (targetFile instanceof XmlFile) {
 					return (XmlFile)targetFile;
@@ -73,13 +95,21 @@ public class LiferayXmlSchemaProvider extends XmlSchemaProvider {
 			return false;
 		}
 
-		if (psiFile.getName().equals("portlet-model-hints.xml")) {
+		String fileName = psiFile.getName();
+
+		if ("portlet-model-hints.xml".equals(fileName)) {
 			return true;
 		}
 
-		if (psiFile.getName().equals("default.xml")) {
-			if ((psiFile.getParent() != null) && (psiFile.getParent().getName().equals("custom-sql"))) {
-				return true;
+		if ("default.xml".equals(fileName)) {
+			PsiDirectory parentDirectory = psiFile.getParent();
+
+			if (parentDirectory != null) {
+				String parentDirectoryName = parentDirectory.getName();
+
+				if ("custom-sql".equals(parentDirectoryName)) {
+					return true;
+				}
 			}
 		}
 

--- a/src/main/java/com/liferay/ide/idea/language/LiferayXmlSchemaProvider.java
+++ b/src/main/java/com/liferay/ide/idea/language/LiferayXmlSchemaProvider.java
@@ -34,7 +34,7 @@ public class LiferayXmlSchemaProvider extends XmlSchemaProvider {
 
 		if (psiFile.getName().equals("portlet-model-hints.xml")) {
 			targetFileUrl = LiferayXmlSchemaProvider.class.getResource(
-			        "/definitions/liferay-portlet-model-hints_7_0_0.xsd"
+			        "/xsd/liferay-portlet-model-hints_7_0_0.xsd"
             );
 		} else if (
 				(psiFile.getName().equals("default.xml")) &&
@@ -42,7 +42,7 @@ public class LiferayXmlSchemaProvider extends XmlSchemaProvider {
                 (psiFile.getParent().getName().equals("custom-sql"))
         ) {
 			targetFileUrl = LiferayXmlSchemaProvider.class.getResource(
-			        "/definitions/liferay-custom-sql_7_0_0.xsd"
+			        "/xsd/liferay-custom-sql_7_0_0.xsd"
             );
 		}
 

--- a/src/main/java/com/liferay/ide/idea/language/LiferayXmlSchemaProvider.java
+++ b/src/main/java/com/liferay/ide/idea/language/LiferayXmlSchemaProvider.java
@@ -1,0 +1,89 @@
+package com.liferay.ide.idea.language;
+
+import com.intellij.ide.highlighter.XmlFileType;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.xml.XmlFile;
+import com.intellij.xml.XmlSchemaProvider;
+
+import java.net.URL;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Provides XML Schema files for portlet-model-hints.xml and custom-sql/default.xml
+ *
+ * @author Dominik Marks
+ */
+public class LiferayXmlSchemaProvider extends XmlSchemaProvider {
+
+	@Nullable
+	@Override
+	public XmlFile getSchema(@NotNull String url, @Nullable Module module, @NotNull PsiFile baseFile) {
+		URL targetFileUrl = null;
+
+		PsiFile psiFile = baseFile;
+
+		if (baseFile.getOriginalFile() != null) {
+			psiFile = baseFile.getOriginalFile();
+		}
+
+		if (psiFile.getName().equals("portlet-model-hints.xml")) {
+			targetFileUrl = LiferayXmlSchemaProvider.class.getResource(
+			        "/definitions/liferay-portlet-model-hints_7_0_0.xsd"
+            );
+		} else if (
+				(psiFile.getName().equals("default.xml")) &&
+                (psiFile.getParent() != null) &&
+                (psiFile.getParent().getName().equals("custom-sql"))
+        ) {
+			targetFileUrl = LiferayXmlSchemaProvider.class.getResource(
+			        "/definitions/liferay-custom-sql_7_0_0.xsd"
+            );
+		}
+
+		if (targetFileUrl != null) {
+			VirtualFile virtualFile = VfsUtil.findFileByURL(targetFileUrl);
+
+			if (virtualFile != null) {
+				PsiFile targetFile = PsiManager.getInstance(baseFile.getProject()).findFile(virtualFile);
+
+				if (targetFile instanceof XmlFile) {
+					return (XmlFile)targetFile;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	@Override
+	public boolean isAvailable(@NotNull XmlFile file) {
+		PsiFile psiFile = file;
+
+		if (file.getOriginalFile() != null) {
+			psiFile = file.getOriginalFile();
+		}
+
+		if (psiFile.getFileType() != XmlFileType.INSTANCE) {
+			return false;
+		}
+
+		if (psiFile.getName().equals("portlet-model-hints.xml")) {
+			return true;
+		}
+
+		if (psiFile.getName().equals("default.xml")) {
+			if ((psiFile.getParent() != null) && (psiFile.getParent().getName().equals("custom-sql"))) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,6 +36,7 @@
 		<codeInsight.lineMarkerProvider language="XML" implementationClass="com.liferay.ide.idea.language.LiferayServiceXMLLineMarkerProvider"/>
 		<codeInsight.lineMarkerProvider language="JAVA" implementationClass="com.liferay.ide.idea.language.LiferayServiceJavaImplLineMarkerProvider"/>
 		<standardResourceProvider implementation="com.liferay.ide.idea.language.LiferayDefinitionsResourceProvider"/>
+		<xml.schemaProvider implementation="com.liferay.ide.idea.language.LiferayXmlSchemaProvider" />
 	</extensions>
 
 </idea-plugin>

--- a/src/main/resources/xsd/liferay-custom-sql_7_0_0.xsd
+++ b/src/main/resources/xsd/liferay-custom-sql_7_0_0.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:element name="custom-sql">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="sql"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="sql">
+        <xs:complexType mixed="true">
+            <xs:attribute name="file"/>
+            <xs:attribute name="id"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/src/main/resources/xsd/liferay-portlet-model-hints_7_0_0.xsd
+++ b/src/main/resources/xsd/liferay-portlet-model-hints_7_0_0.xsd
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:element name="model-hints">
+        <xs:complexType>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element minOccurs="0" ref="hint-collection"/>
+                <xs:element minOccurs="0" ref="model"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="hint-collection">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="hint"/>
+            </xs:sequence>
+            <xs:attribute name="name" use="required"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="hint">
+        <xs:complexType mixed="true">
+            <xs:attribute name="name" use="required">
+                <xs:simpleType>
+                    <xs:restriction base="xs:token">
+                        <xs:enumeration value="auto-escape"/>
+                        <xs:enumeration value="auto-size"/>
+                        <xs:enumeration value="day-nullable"/>
+                        <xs:enumeration value="default-month-delta"/>
+                        <xs:enumeration value="default-value"/>
+                        <xs:enumeration value="display-height"/>
+                        <xs:enumeration value="display-width"/>
+                        <xs:enumeration value="editor"/>
+                        <xs:enumeration value="max-length"/>
+                        <xs:enumeration value="month-nullable"/>
+                        <xs:enumeration value="secret"/>
+                        <xs:enumeration value="show-time"/>
+                        <xs:enumeration value="type"/>
+                        <xs:enumeration value="upper-case"/>
+                        <xs:enumeration value="year-nullable"/>
+                        <xs:enumeration value="year-range-delta"/>
+                        <xs:enumeration value="year-range-future"/>
+                        <xs:enumeration value="year-range-past"/>
+                        <xs:enumeration value="custom"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="model">
+        <xs:complexType>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element minOccurs="0" ref="default-hints"/>
+                <xs:element minOccurs="0" ref="field"/>
+            </xs:sequence>
+            <xs:attribute name="name" use="required"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="default-hints">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="hint"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="field">
+        <xs:complexType>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+                <xs:element minOccurs="0" ref="hint-collection"/>
+                <xs:element minOccurs="0" ref="hint"/>
+                <xs:element minOccurs="0" ref="sanitize"/>
+                <xs:element minOccurs="0" ref="validator"/>
+            </xs:sequence>
+            <xs:attribute name="name" use="required"/>
+            <xs:attribute name="type" use="required"/>
+            <xs:attribute name="localized"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="sanitize">
+        <xs:complexType>
+            <xs:attribute name="content-type" use="required"/>
+            <xs:attribute name="modes" use="required"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="validator">
+        <xs:complexType mixed="true">
+            <xs:attribute name="name" use="required">
+                <xs:simpleType>
+                    <xs:restriction base="xs:token">
+                        <xs:enumeration value="acceptFiles"/>
+                        <xs:enumeration value="alpha"/>
+                        <xs:enumeration value="alphanum"/>
+                        <xs:enumeration value="date"/>
+                        <xs:enumeration value="digits"/>
+                        <xs:enumeration value="email"/>
+                        <xs:enumeration value="equalTo"/>
+                        <xs:enumeration value="iri"/>
+                        <xs:enumeration value="max"/>
+                        <xs:enumeration value="maxLength"/>
+                        <xs:enumeration value="min"/>
+                        <xs:enumeration value="minLength"/>
+                        <xs:enumeration value="number"/>
+                        <xs:enumeration value="range"/>
+                        <xs:enumeration value="rangeLength"/>
+                        <xs:enumeration value="required"/>
+                        <xs:enumeration value="url"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="error-message"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>


### PR DESCRIPTION
The plugin can provide XML Schema for XML files which do not have a schema definition. By this pull request I would like to contribute XML Schema definitions for portlet-model-hints.xml and custom-sql/default.xml. 
By providing the XML Schema code completion is possible in Model Hints and Custom SQL XML files, too.